### PR TITLE
Include newtype name in panic message when constructing invalid value

### DIFF
--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -54,11 +54,11 @@ This function panics if `value` is greater than ", $max, "."
                 pub fn new(value: $repr) -> $name {
                     #[cfg(feature = "std")]
                     {
-                        assert!($name::is_valid(value), format!("{} is not a valid value", value));
+                        assert!($name::is_valid(value), format!(concat!("{} is not a valid ", stringify!($name), " value"), value));
                     }
                     #[cfg(feature = "no_std")]
                     {
-                        assert!($name::is_valid(value), "Not a valid value");
+                        assert!($name::is_valid(value), concat!("not a valid ", stringify!($name), " value"));
                     }
                     $name(value)
                 }

--- a/src/u7_mod.rs
+++ b/src/u7_mod.rs
@@ -39,3 +39,19 @@ impl_try_from_primitive_to_newtype!(u128, U7);
 impl_try_from_primitive_to_newtype!(i128, U7);
 impl_try_from_primitive_to_newtype!(usize, U7);
 impl_try_from_primitive_to_newtype!(isize, U7);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_successful() {
+        U7::new(127);
+    }
+
+    #[test]
+    #[should_panic(expected = "128 is not a valid U7 value")]
+    fn new_failing() {
+        U7::new(128);
+    }
+}


### PR DESCRIPTION
can greatly help when analyzing production backtraces, especially because
newtypes are optimized away